### PR TITLE
Switch ACR authentication from admin credentials to Azure AD

### DIFF
--- a/helm/sample-api/templates/deployment.yaml
+++ b/helm/sample-api/templates/deployment.yaml
@@ -30,7 +30,5 @@ spec:
               key: password
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-      imagePullSecrets:
-      - name: acr-secret
 
 

--- a/k8config/acr-secret.yaml
+++ b/k8config/acr-secret.yaml
@@ -1,8 +1,1 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: acr-secret
-  namespace: default
-data:
-  .dockerconfigjson: eyJhdXRocyI6eyJteWFjcmRldi5henVyZWNvci5pbyI6eyJ1c2VybmFtZSI6Im15YWNyZGV2IiwicGFzc3dvcmQiOiJHRmIraUhZWjhHNG5VR1hxRVhXZy9uRHB6WlhWUlFCdTJBdTU5dHV5SUsrQUNSQ2VVUHBRIiwicGFzc3dvcmQyIjoicUQ2dkRZY1E3N3BzVndyaG54ZnpVazh4Yk9JN09PUlFKUTZ1VHFKemVNK0FDUkF2V3NVMCIsImF1dGgiOiJkWE5sY2xWbGJtRjBhVzl1T2kxaloyOTJhV0ZzYVd4cGRIa2dUVkZPVTFvS1lURXoiLCJlbWFpbCI6ImV4YW1wbGUuY29tIn19fQ==
-type: kubernetes.io/dockerconfigjson
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,6 +82,20 @@ module "storage" {
   depends_on = [azurerm_resource_group.main]
 }
 
+resource "azurerm_ad_application" "acr_app" {
+  display_name = "acr-app"
+}
+
+resource "azurerm_ad_service_principal" "acr_sp" {
+  application_id = azurerm_ad_application.acr_app.application_id
+}
+
+resource "azurerm_role_assignment" "aks_acr_pull" {
+  scope                = module.acr.acr_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_ad_service_principal.acr_sp.id
+}
+
 resource "random_string" "suffix" {
   length  = 6
   special = false

--- a/terraform/modules/acr/main.tf
+++ b/terraform/modules/acr/main.tf
@@ -3,5 +3,5 @@ resource "azurerm_container_registry" "acr" {
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = "Basic"
-  admin_enabled       = true
+  admin_enabled       = false
 }

--- a/terraform/modules/acr/outputs.tf
+++ b/terraform/modules/acr/outputs.tf
@@ -1,15 +1,3 @@
-output "acr_login_server" {
-  value = azurerm_container_registry.acr.login_server
-}
-
-output "acr_admin_username" {
-  value = azurerm_container_registry.acr.admin_username
-}
-
-output "acr_admin_password" {
-  value = azurerm_container_registry.acr.admin_password
-}
-
 output "acr_id" {
   value = azurerm_container_registry.acr.id
 }


### PR DESCRIPTION
This PR changes the authentication method for Azure Container Registry (ACR) from admin credentials to Azure AD-based authentication. Changes include:

- Disabled admin authentication on ACR by setting `admin_enabled = false`
- Removed ACR admin credential outputs from terraform
- Added Azure AD application and service principal for ACR authentication
- Configured AcrPull role assignment for the service principal
- Removed `imagePullSecrets` from Helm deployment
- Deleted `acr-secret.yaml` containing admin credentials

This change improves security by using Azure AD-based authentication instead of static admin credentials for ACR access.