### PR TITLE
Add Azure Storage infrastructure for Terraform state

### DIFF
--- a/infra/dev/backend.tf
+++ b/infra/dev/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "cc-azure-rg"
+    storage_account_name = "cc-storage-acc"
+    container_name       = "cc-statefile"
+    key                 = "terraform.tfstate"
+  }
+}

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -1,0 +1,3 @@
+module "storage" {
+  source = "../modules/storage"
+}

--- a/infra/dev/outputs.tf
+++ b/infra/dev/outputs.tf
@@ -1,0 +1,1 @@
+# Add any outputs needed from the dev environment

--- a/infra/dev/variables.tf
+++ b/infra/dev/variables.tf
@@ -1,0 +1,1 @@
+# Add any variables needed for the dev environment

--- a/infra/dev/variables.tfvars
+++ b/infra/dev/variables.tfvars
@@ -1,0 +1,1 @@
+# Add any variable values specific to the dev environment

--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -1,0 +1,18 @@
+resource "azurerm_resource_group" "example" {
+  name     = "cc-azure-rg"
+  location = "East US"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "cc-storage-acc"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "cc_statefile" {
+  name                  = "cc-statefile"
+  storage_account_name  = azurerm_storage_account.example.name
+  container_access_type = "private"
+}

--- a/infra/modules/storage/outputs.tf
+++ b/infra/modules/storage/outputs.tf
@@ -1,0 +1,1 @@
+# Add any outputs needed from the storage module

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -1,0 +1,1 @@
+# Add any variables needed for the storage module


### PR DESCRIPTION
This PR adds Azure Storage infrastructure for managing Terraform state files. The changes include:

- Created a new storage module with:
  - Azure Resource Group
  - Storage Account
  - Storage Container for Terraform state files
- Set up dev environment configuration with:
  - Storage module implementation
  - Azure backend configuration for state management
  
The infrastructure uses:
- Resource Group: `cc-azure-rg` in East US
- Storage Account: `cc-storage-acc` with Standard tier and LRS replication
- Private Storage Container: `cc-statefile`

This setup provides a secure and centralized location for storing Terraform state files.