### PR TITLE
Add GAP_ANALYSIS.md to report discrepancies with README

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -1,0 +1,47 @@
+# Gap Analysis: README vs. Codebase
+
+This document outlines the discrepancies found between the `readme` file and the actual code and structure within this repository.
+
+## Summary of Discrepancies
+
+The `readme` file describes a comprehensive project involving a Python-based API, a PostgreSQL database, extensive Azure infrastructure managed by Terraform, containerization with Docker, orchestration with Helm, and a CI/CD pipeline for deployment to Azure Kubernetes Service (AKS).
+
+The actual codebase, however, represents a much simpler setup: a basic "Hello World" Node.js application with a different directory structure and a less elaborate CI/CD configuration.
+
+## Specific Gaps Identified
+
+1.  **Application Language and Functionality:**
+    *   **README:** Describes a Python API (mentioning `main.py`, `requirements.txt`). It also implies functionality requiring a database.
+    *   **Codebase:** Contains a Node.js Express application (`app/app.js`, `app/package.json`) that serves a simple "Hello World" message and has no database interaction.
+
+2.  **Directory Structure:**
+    *   **README:** Proposes a directory structure like `docker/api/app/` for application code, `helm/sample-api/` for Helm charts, and `terraform/modules/` for Terraform modules.
+    *   **Codebase:** The application code is in `app/`. The `docker/`, `helm/`, and `terraform/` (as described in the README) directories are largely missing or structured differently (e.g., `infra/` for Terraform, `app/Dockerfile` instead of `docker/api/Dockerfile`).
+
+3.  **Database:**
+    *   **README:** Extensively details the planning, setup, configuration, and deployment of a database (specifically PostgreSQL).
+    *   **Codebase:** No database code, configuration, or related files are present in the `app/` directory or elsewhere in the repository structure that was listed.
+
+4.  **Application Port:**
+    *   **README:** Does not explicitly state the API port.
+    *   **Codebase:** The Node.js application in `app/app.js` listens on port `8080`. While not a direct contradiction, it's a detail mismatch if other ports were assumed for a Python API.
+
+5.  **Dockerfile Location:**
+    *   **README:** Specifies `docker/api/Dockerfile`.
+    *   **Codebase:** The Dockerfile is located at `app/Dockerfile`.
+
+6.  **Helm Chart Presence and Location:**
+    *   **README:** Describes Helm charts for a sample API (`helm/sample-api/`) and PostgreSQL (`helm/postgresql/`).
+    *   **Codebase:** These Helm chart directories are not present in the repository.
+
+7.  **Terraform Modules and Structure:**
+    *   **README:** Details a `terraform/` directory with multiple modules (e.g., `acr`, `aks`, `database`, `networking`).
+    *   **Codebase:** An `infra/` directory exists with a `modules/storage/` subdirectory, which differs significantly from the README's description. Most of the modules listed in the README are absent.
+
+8.  **CI/CD Workflow File Naming:**
+    *   **README:** Mentions `.github/workflows/build-and-push-docker.yml` and `.github/workflows/deploy-to-aks.yml`.
+    *   **Codebase:** The existing workflow file is `.github/workflows/app-build.yaml`.
+
+## Conclusion
+
+There is a significant divergence between the project described in the `readme` and the actual contents of the repository. The `readme` appears to outline a target architecture and a comprehensive set of tasks for a sophisticated cloud-native application, while the current codebase is a minimal placeholder or starting point.


### PR DESCRIPTION
This commit introduces a new file, GAP_ANALYSIS.md, which details the differences found between the project description in the 'readme' file and the actual state of the codebase.

The analysis covers several areas:
- Application language (Python in README vs. Node.js in code)
- Directory structure mismatches for application code, Docker, Helm, and Terraform
- Absence of database components described in the README
- Differences in Dockerfile location
- Missing Helm charts
- Discrepancies in Terraform module structure and presence
- CI/CD workflow file naming variations

This report provides a clear overview of the current gaps, serving as a reference for future development or alignment efforts.