### PR TITLE
Add Terraform CI/CD workflow and disable app workflows

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -9,27 +9,28 @@ on:
       - 'app/Dockerfile'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Azure
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZ_CRED }}  # Service principal credentials
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v3
-        with:
-          context: ./app
-          push: false  # Set to false since we are not pushing to ACR
-          tags: |
-            hello-world:${{ github.sha }}
-
-      # Uncomment the following steps to push the image to ACR when ready
-      # - name: Push Docker Image to ACR
-      #   run: |
-      #     docker push youracrname.azurecr.io/hello-world:${{ github.sha }}
-      #     docker push youracrname.azurecr.io/hello-world:latest
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v3
+#
+#      - name: Login to Azure
+#        uses: azure/login@v1
+#        with:
+#          creds: ${{ secrets.AZ_CRED }}  # Service principal credentials
+#
+#      - name: Build Docker Image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ./app
+#          push: false  # Set to false since we are not pushing to ACR
+#          tags: |
+#            hello-world:${{ github.sha }}
+#
+#      # Uncomment the following steps to push the image to ACR when ready
+#      # - name: Push Docker Image to ACR
+#      #   run: |
+#      #     docker push youracrname.azurecr.io/hello-world:${{ github.sha }}
+#      #     docker push youracrname.azurecr.io/hello-world:latest
+```

--- a/.github/workflows/deploy-to-aks.yml
+++ b/.github/workflows/deploy-to-aks.yml
@@ -10,58 +10,58 @@ on:
       # Potentially trigger if the image build workflow runs successfully (workflow_run)
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    # Add environment if you use GitHub environments for protection rules/secrets
-    # environment: production 
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Login to Azure
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZ_CRED }} # Service principal credentials
-
-      - name: Set up Kubectl
-        uses: azure/setup-kubectl@v3
-        # id: install # No id needed if not referencing output
-
-      - name: Get AKS Credentials
-        uses: azure/aks-set-context@v3
-        with:
-          resource-group: ${{ secrets.AZ_RESOURCE_GROUP }} # Or use Terraform output
-          cluster-name: ${{ secrets.AZ_AKS_CLUSTER_NAME }}   # Or use Terraform output
-        # id: login # No id needed if not referencing output
-
-      - name: Setup Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: 'v3.x' # Specify Helm version
-        # id: helm-install
-
-      # Placeholder for getting image tag from build job or other source
-      # This would typically be an output from the build-and-push-docker.yml workflow
-      # or a fixed tag like 'latest' if that's your strategy.
-      - name: Set Image Tag
-        id: image_tag
-        run: echo "IMAGE_TAG=latest" >> $GITHUB_ENV # Replace 'latest' with actual tag
-
-      - name: Deploy PostgreSQL Helm Chart
-        run: |
-          helm upgrade --install postgresql-release ./helm/postgresql             --namespace default             --create-namespace             --set postgresql.password=${{ secrets.DB_PASSWORD }}             # Add other necessary values for postgresql chart
-            --wait # Optional: wait for resources to be ready
-
-      - name: Deploy Sample API Helm Chart
-        run: |
-          helm upgrade --install sample-api-release ./helm/sample-api             --namespace default             --create-namespace             --set image.tag=${{ env.IMAGE_TAG }}             --set image.repository=${{ secrets.ACR_NAME }}.azurecr.io/sample-node-api \ # Replace with your ACR name logic
-            --set postgresql.password=${{ secrets.DB_PASSWORD }}             --set postgresql.host=postgresql-release-postgresql \ # Assuming postgresql chart release name is 'postgresql-release' and service is 'postgresql-release-postgresql'
-            # Add other necessary values for sample-api chart
-            --wait # Optional: wait for resources to be ready
-
-      # Placeholder for any post-deployment steps (e.g., smoke tests)
-      # - name: Verify deployment
-      #   run: |
-      #     kubectl get pods -n default
-      #     # Add more verification steps
+#  deploy:
+#    runs-on: ubuntu-latest
+#    # Add environment if you use GitHub environments for protection rules/secrets
+#    # environment: production 
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v3
+#
+#      - name: Login to Azure
+#        uses: azure/login@v1
+#        with:
+#          creds: ${{ secrets.AZ_CRED }} # Service principal credentials
+#
+#      - name: Set up Kubectl
+#        uses: azure/setup-kubectl@v3
+#        # id: install # No id needed if not referencing output
+#
+#      - name: Get AKS Credentials
+#        uses: azure/aks-set-context@v3
+#        with:
+#          resource-group: ${{ secrets.AZ_RESOURCE_GROUP }} # Or use Terraform output
+#          cluster-name: ${{ secrets.AZ_AKS_CLUSTER_NAME }}   # Or use Terraform output
+#        # id: login # No id needed if not referencing output
+#
+#      - name: Setup Helm
+#        uses: azure/setup-helm@v3
+#        with:
+#          version: 'v3.x' # Specify Helm version
+#        # id: helm-install
+#
+#      # Placeholder for getting image tag from build job or other source
+#      # This would typically be an output from the build-and-push-docker.yml workflow
+#      # or a fixed tag like 'latest' if that's your strategy.
+#      - name: Set Image Tag
+#        id: image_tag
+#        run: echo "IMAGE_TAG=latest" >> $GITHUB_ENV # Replace 'latest' with actual tag
+#
+#      - name: Deploy PostgreSQL Helm Chart
+#        run: |
+#          helm upgrade --install postgresql-release ./helm/postgresql #            --namespace default #            --create-namespace #            --set postgresql.password=${{ secrets.DB_PASSWORD }} #            # Add other necessary values for postgresql chart
+#            --wait # Optional: wait for resources to be ready
+#
+#      - name: Deploy Sample API Helm Chart
+#        run: |
+#          helm upgrade --install sample-api-release ./helm/sample-api #            --namespace default #            --create-namespace #            --set image.tag=${{ env.IMAGE_TAG }} #            --set image.repository=${{ secrets.ACR_NAME }}.azurecr.io/sample-node-api \ # Replace with your ACR name logic
+#            --set postgresql.password=${{ secrets.DB_PASSWORD }} #            --set postgresql.host=postgresql-release-postgresql \ # Assuming postgresql chart release name is 'postgresql-release' and service is 'postgresql-release-postgresql'
+#            # Add other necessary values for sample-api chart
+#            --wait # Optional: wait for resources to be ready
+#
+#      # Placeholder for any post-deployment steps (e.g., smoke tests)
+#      # - name: Verify deployment
+#      #   run: |
+#      #     kubectl get pods -n default
+#      #     # Add more verification steps

--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -1,0 +1,63 @@
+name: Terraform Infrastructure CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/**' # Trigger only when files in terraform directory change
+      - '.github/workflows/terraform-infra.yml' # Or when this workflow itself changes
+
+env:
+  # Set ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_SUBSCRIPTION_ID, ARM_TENANT_ID as GitHub secrets
+  # These are used by Terraform AzureRM provider for authentication if not using azure/login
+  # However, using azure/login is often preferred for more features.
+  # TF_LOG: "DEBUG" # Uncomment for detailed Terraform logging if needed
+  TF_WORKING_DIR: "terraform" # Set working directory for Terraform commands
+
+jobs:
+  apply_infrastructure:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    # environment: production # Optional: if using GitHub environments
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "1.6.5" # Specify your desired Terraform version
+          # terraform_wrapper: true # Optional: if you want to use the wrapper
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZ_CRED }} # Assumes AZ_CRED secret is configured (JSON output of `az ad sp create-for-rbac`)
+
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -input=false -no-color -out=tfplan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        # Continue on error to allow plan output even if there are diffs that would cause an error code
+        # continue-on-error: true 
+
+      # Optional: Add a step to output the plan, e.g., for pull request comments
+      # - name: Show Plan
+      #   run: terraform show -no-color tfplan
+      #   working-directory: ${{ env.TF_WORKING_DIR }}
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push' # Only apply on direct push to main
+        run: terraform apply -auto-approve -input=false tfplan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+```

--- a/readme
+++ b/readme
@@ -212,23 +212,30 @@ Each module is designed to be reusable and is called from the root `main.tf`. Mo
 
 CI/CD Pipeline Explanation
 
-1. Build and Push Docker Image (`build-and-push-docker.yml`)
-This workflow is triggered by pushes to the main branch. It performs the following steps:
+The CI/CD pipelines are managed using GitHub Actions. The workflows are defined in the `.github/workflows/` directory.
 
-Checkout Code: Retrieves the latest code from the repository.
-Set Up Docker: Configures Docker Buildx for building multi-platform images.
-Login to Azure: Authenticates with Azure using the credentials set up in the GitHub repository secrets.
-Login to ACR: Authenticates with Azure Container Registry.
-Build and Push Docker Image: Builds the Docker image for the sample Node.js API (from `app/Dockerfile`) and pushes it to ACR.
+1.  **Terraform Infrastructure Workflow (`terraform-infra.yml`)**
+    *   **Purpose:** Automates the provisioning and management of the Azure infrastructure using Terraform.
+    *   **Trigger:** Runs on pushes to the `main` branch when changes are detected in the `terraform/` directory or the workflow file itself.
+    *   **Actions:**
+        *   Checks out the code.
+        *   Sets up Terraform.
+        *   Logs into Azure using credentials stored in GitHub secrets.
+        *   Runs `terraform init` to initialize the Terraform working directory.
+        *   Runs `terraform validate` to check the configuration's syntax.
+        *   Runs `terraform plan` to create an execution plan.
+        *   Runs `terraform apply -auto-approve` to apply the changes to the infrastructure. This step is conditional and only runs on pushes to the `main` branch.
 
-2. Deploy to AKS (`deploy-to-aks.yml`)
-This workflow is triggered by pushes to the main branch. It performs the following steps:
+2.  **Build and Push Docker Image (`build-and-push-docker.yml`) - Temporarily Disabled**
+    *   **Original Purpose:** Builds the Docker image for the sample Node.js API and pushes it to Azure Container Registry (ACR).
+    *   **Current Status:** This workflow is temporarily disabled by having its job steps commented out. The trigger is on pushes to `main` for changes in `app/**` or `app/Dockerfile`.
 
-Checkout Code: Retrieves the latest code from the repository.
-Login to Azure: Authenticates with Azure using the credentials set up in the GitHub repository secrets.
-Set Up kubectl: Configures kubectl to interact with the AKS cluster.
-Get AKS Credentials: Retrieves the AKS cluster credentials to configure kubectl.
-Deploy to AKS: Uses Helm to deploy the sample Node.js API and PostgreSQL to the AKS cluster, referencing the Docker images stored in ACR.
+3.  **Deploy to AKS (`deploy-to-aks.yml`) - Temporarily Disabled**
+    *   **Original Purpose:** Deploys the sample Node.js API and PostgreSQL to the Azure Kubernetes Service (AKS) cluster using Helm charts.
+    *   **Current Status:** This workflow is temporarily disabled by having its job steps commented out. The trigger is on pushes to `main` for changes in `helm/**` or the workflow file itself.
+
+**Note on Workflow Activation:**
+The application build and deployment workflows (`build-and-push-docker.yml` and `deploy-to-aks.yml`) can be re-enabled by uncommenting their job steps once the infrastructure is successfully provisioned and ACR/AKS details are available and configured (potentially as secrets or outputs from the Terraform workflow).
 Deployment Process
 Build and Push Docker Image:
 


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`terraform-infra.yml`) to automate the deployment of Azure infrastructure using Terraform. The workflow runs on pushes to main and executes terraform init, validate, plan, and apply.

The existing application CI/CD workflows (`build-and-push-docker.yml` and `deploy-to-aks.yml`) have been temporarily disabled by commenting out their job steps. This is to allow infrastructure to be managed independently first.

The README has been updated to reflect these changes in the CI/CD pipeline explanation.