### PR TITLE
Fix: Add missing vnet_name variable to networking module

### DIFF
--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -13,3 +13,9 @@ variable "module_enabled" {
   type        = bool
   default     = false # Disabled by default
 }
+
+variable "vnet_name" {
+  description = "The name for the virtual network."
+  type        = string
+  default     = "vnet-default"
+}


### PR DESCRIPTION
The Terraform validation was failing because the root main.tf was passing a `vnet_name` argument to the `networking` module, but this variable was not defined in the module's `variables.tf`.

This commit adds the `vnet_name` variable definition to `terraform/modules/networking/variables.tf` to resolve the "Unsupported argument" error.