### PR TITLE
Fix: Add missing app_insights_name variable to app_insights module

### DIFF
--- a/terraform/modules/app-insights/variables.tf
+++ b/terraform/modules/app-insights/variables.tf
@@ -13,3 +13,9 @@ variable "module_enabled" {
   type        = bool
   default     = false # Disabled by default
 }
+
+variable "app_insights_name" {
+  description = "The name for the Application Insights instance."
+  type        = string
+  default     = "appi-default"
+}


### PR DESCRIPTION
The Terraform validation was failing because the root main.tf was passing an `app_insights_name` argument to the `app_insights` module, but this variable was not defined in the module's `variables.tf`.

This commit adds the `app_insights_name` variable definition to `terraform/modules/app-insights/variables.tf` to resolve the "Unsupported argument" error.