### PR TITLE
Fix: Add missing variables to Terraform modules

### DIFF
--- a/terraform/modules/log-analytics/variables.tf
+++ b/terraform/modules/log-analytics/variables.tf
@@ -13,3 +13,9 @@ variable "module_enabled" {
   type        = bool
   default     = false # Disabled by default
 }
+
+variable "log_analytics_workspace_name" {
+  description = "The name for the Log Analytics workspace."
+  type        = string
+  default     = "logws-default"
+}


### PR DESCRIPTION
This commit addresses Terraform validation errors caused by arguments being passed to modules from the root main.tf without corresponding variable definitions in the modules themselves.

Changes:
- Added `log_analytics_workspace_name` variable to `terraform/modules/log-analytics/variables.tf`.

Verified that `app_insights`, `networking`, and `storage` modules now have the necessary variables defined for arguments passed from the root configuration (fixes applied in previous commits or verified in this sequence). This should resolve the "Unsupported argument" errors.