### PR TITLE
Fix: Correct Terraform validation errors for database module

### DIFF
--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -11,11 +11,10 @@ resource "azurerm_postgresql_flexible_server" "main" {
   backup_retention_days      = var.backup_retention_days
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 
-  # For simplicity, allow public access from any Azure service and disable SSL enforcement.
-  # In a production environment, configure VNet integration or private endpoints,
-  # and enforce SSL.
+  # For simplicity, allow public access from any Azure service.
+  # In a production environment, configure VNet integration or private endpoints.
+  # SSL is typically enforced by default on Flexible Servers.
   public_network_access_enabled = true # Set to false for private access
-  ssl_enforcement_enabled       = false # Set to true in production
 
   # Flexible server requires zone to be set, or high_availability to be configured
   zone = "1" # Or other availability zone like "2", "3". Pick one available in your region.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -15,5 +15,5 @@ output "acr_login_server" {
 
 output "postgresql_server_fqdn" {
   description = "The FQDN of the PostgreSQL server."
-  value       = module.database.postgresql_server_fqdn_output # Assuming the module has an output named 'postgresql_server_fqdn_output'
+  value       = module.database.postgresql_server_fqdn 
 }


### PR DESCRIPTION
This commit addresses two Terraform validation errors:

1.  Unsupported attribute in root `outputs.tf`: I corrected the output for `postgresql_server_fqdn` to reference `module.database.postgresql_server_fqdn` instead of `module.database.postgresql_server_fqdn_output`.

2.  Unsupported argument in `database` module: I removed the `ssl_enforcement_enabled` argument from the `azurerm_postgresql_flexible_server` resource in `terraform/modules/database/main.tf` as it's not a valid argument for this resource type. SSL is typically enforced by default on Azure PostgreSQL Flexible Servers.