### PR TITLE
feat: Allow manual apply/destroy for Terraform workflow

### DIFF
--- a/.github/workflows/terraform-infra.yml
+++ b/.github/workflows/terraform-infra.yml
@@ -1,13 +1,16 @@
 name: Terraform Infrastructure CI/CD
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'terraform/**'
-      - '.github/workflows/terraform-infra.yml'
   workflow_dispatch:
+    inputs:
+      action:
+        description: 'The Terraform action to perform: apply or destroy'
+        required: true
+        default: 'apply'
+        type: choice
+        options:
+          - apply
+          - destroy
 
 jobs:
   deploy-infra:
@@ -39,6 +42,10 @@ jobs:
         if: always()
         run: terraform show -no-color tfplan
 
+      - name: Terraform Destroy
+        if: github.event.inputs.action == 'destroy' && github.ref == 'refs/heads/main'
+        run: terraform destroy -auto-approve
+
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'   
+        if: github.event.inputs.action == 'apply' && github.ref == 'refs/heads/main'
         run: terraform apply -auto-approve -input=false tfplan

--- a/readme
+++ b/readme
@@ -226,6 +226,22 @@ The CI/CD pipelines are managed using GitHub Actions. The workflows are defined 
         *   Runs `terraform plan` to create an execution plan.
         *   Runs `terraform apply -auto-approve` to apply the changes to the infrastructure. This step is conditional and only runs on pushes to the `main` branch.
 
+### Manually Triggering the Terraform Workflow
+
+The Terraform infrastructure deployment (`Terraform Infrastructure CI/CD` workflow) has been configured for manual triggering, providing direct control over when infrastructure changes are applied or destroyed.
+
+To manually run this workflow:
+
+1.  Navigate to the **Actions** tab of this GitHub repository.
+2.  In the left sidebar, click on the "**Terraform Infrastructure CI/CD**" workflow.
+3.  Above the list of workflow runs, click the "**Run workflow**" button (usually on the right side).
+4.  You will see a dropdown menu labeled "**The Terraform action to perform: apply or destroy**".
+    *   Choose `apply` to build or update the infrastructure as defined in the Terraform files.
+    *   Choose `destroy` to remove all infrastructure managed by this Terraform configuration.
+5.  Click the green "**Run workflow**" button to start the process.
+
+**Caution:** The `destroy` action will permanently delete your Azure infrastructure managed by this workflow. Use this option with extreme care and ensure you understand its consequences, especially in a production environment.
+
 2.  **Build and Push Docker Image (`build-and-push-docker.yml`) - Temporarily Disabled**
     *   **Original Purpose:** Builds the Docker image for the sample Node.js API and pushes it to Azure Container Registry (ACR).
     *   **Current Status:** This workflow is temporarily disabled by having its job steps commented out. The trigger is on pushes to `main` for changes in `app/**` or `app/Dockerfile`.


### PR DESCRIPTION
Modifies the Terraform GitHub Actions workflow (`terraform-infra.yml`) to be manually triggered via `workflow_dispatch`.

This change introduces an 'action' input, allowing you to specify whether to 'apply' or 'destroy' the Terraform-managed infrastructure.

The workflow will:
- Trigger manually from the GitHub Actions tab.
- Require selection of 'apply' or 'destroy'.
- Conditionally execute `terraform apply -auto-approve` for 'apply'.
- Conditionally execute `terraform destroy -auto-approve` for 'destroy'.

The `readme` has also been updated to reflect these changes and provide instructions on how you can use the new manual trigger.