### PR TITLE
feat: Enable manual trigger for build and deploy workflows

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,36 +1,32 @@
 name: Build App Container
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'app/**'
-      - 'app/Dockerfile'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag for the Docker image'
+        required: true
+        default: 'latest'
+        type: string
 
 jobs:
-#  build:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v3
-#
-#      - name: Login to Azure
-#        uses: azure/login@v1
-#        with:
-#          creds: ${{ secrets.AZ_CRED }}  # Service principal credentials
-#
-#      - name: Build Docker Image
-#        uses: docker/build-push-action@v3
-#        with:
-#          context: ./app
-#          push: false  # Set to false since we are not pushing to ACR
-#          tags: |
-#            hello-world:${{ github.sha }}
-#
-#      # Uncomment the following steps to push the image to ACR when ready
-#      # - name: Push Docker Image to ACR
-#      #   run: |
-#      #     docker push youracrname.azurecr.io/hello-world:${{ github.sha }}
-#      #     docker push youracrname.azurecr.io/hello-world:latest
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZ_CRED }}  # Service principal credentials
+
+      - name: Build and Push Docker Image to ACR
+        uses: docker/build-push-action@v3
+        with:
+          context: ./app
+          push: true
+          tags: |
+            ${{ secrets.ACR_NAME }}.azurecr.io/hello-world:${{ github.event.inputs.image_tag }}
+            ${{ secrets.ACR_NAME }}.azurecr.io/hello-world:latest
 ```

--- a/.github/workflows/deploy-to-aks.yml
+++ b/.github/workflows/deploy-to-aks.yml
@@ -1,65 +1,68 @@
 name: Deploy to AKS
 
 on:
-  push:
-    branches:
-      - main # Or your deployment branch
-    paths: # Trigger only if relevant Helm charts or this workflow changes
-      - 'helm/**'
-      - '.github/workflows/deploy-to-aks.yml'
-      # Potentially trigger if the image build workflow runs successfully (workflow_run)
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag of the sample-node-api to deploy'
+        required: true
+        default: 'latest'
+        type: string
 
-#jobs:
-#  deploy:
-#    runs-on: ubuntu-latest
-#    # Add environment if you use GitHub environments for protection rules/secrets
-#    # environment: production 
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v3
-#
-#      - name: Login to Azure
-#        uses: azure/login@v1
-#        with:
-#          creds: ${{ secrets.AZ_CRED }} # Service principal credentials
-#
-#      - name: Set up Kubectl
-#        uses: azure/setup-kubectl@v3
-#        # id: install # No id needed if not referencing output
-#
-#      - name: Get AKS Credentials
-#        uses: azure/aks-set-context@v3
-#        with:
-#          resource-group: ${{ secrets.AZ_RESOURCE_GROUP }} # Or use Terraform output
-#          cluster-name: ${{ secrets.AZ_AKS_CLUSTER_NAME }}   # Or use Terraform output
-#        # id: login # No id needed if not referencing output
-#
-#      - name: Setup Helm
-#        uses: azure/setup-helm@v3
-#        with:
-#          version: 'v3.x' # Specify Helm version
-#        # id: helm-install
-#
-#      # Placeholder for getting image tag from build job or other source
-#      # This would typically be an output from the build-and-push-docker.yml workflow
-#      # or a fixed tag like 'latest' if that's your strategy.
-#      - name: Set Image Tag
-#        id: image_tag
-#        run: echo "IMAGE_TAG=latest" >> $GITHUB_ENV # Replace 'latest' with actual tag
-#
-#      - name: Deploy PostgreSQL Helm Chart
-#        run: |
-#          helm upgrade --install postgresql-release ./helm/postgresql #            --namespace default #            --create-namespace #            --set postgresql.password=${{ secrets.DB_PASSWORD }} #            # Add other necessary values for postgresql chart
-#            --wait # Optional: wait for resources to be ready
-#
-#      - name: Deploy Sample API Helm Chart
-#        run: |
-#          helm upgrade --install sample-api-release ./helm/sample-api #            --namespace default #            --create-namespace #            --set image.tag=${{ env.IMAGE_TAG }} #            --set image.repository=${{ secrets.ACR_NAME }}.azurecr.io/sample-node-api \ # Replace with your ACR name logic
-#            --set postgresql.password=${{ secrets.DB_PASSWORD }} #            --set postgresql.host=postgresql-release-postgresql \ # Assuming postgresql chart release name is 'postgresql-release' and service is 'postgresql-release-postgresql'
-#            # Add other necessary values for sample-api chart
-#            --wait # Optional: wait for resources to be ready
-#
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Add environment if you use GitHub environments for protection rules/secrets
+    # environment: production 
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZ_CRED }} # Service principal credentials
+
+      - name: Set up Kubectl
+        uses: azure/setup-kubectl@v3
+        # id: install # No id needed if not referencing output
+
+      - name: Get AKS Credentials
+        uses: azure/aks-set-context@v3
+        with:
+          resource-group: ${{ secrets.AZ_RESOURCE_GROUP }} # Or use Terraform output
+          cluster-name: ${{ secrets.AZ_AKS_CLUSTER_NAME }}   # Or use Terraform output
+        # id: login # No id needed if not referencing output
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.x' # Specify Helm version
+        # id: helm-install
+
+      - name: Set Image Tag
+        id: image_tag
+        run: echo "IMAGE_TAG=${{ github.event.inputs.image_tag }}" >> $GITHUB_ENV
+
+      - name: Deploy PostgreSQL Helm Chart
+        run: |
+          helm upgrade --install postgresql-release ./helm/postgresql \
+            --namespace default \
+            --create-namespace \
+            --set postgresql.password=${{ secrets.DB_PASSWORD }} \
+            --wait # Optional: wait for resources to be ready
+
+      - name: Deploy Sample API Helm Chart
+        run: |
+          helm upgrade --install sample-api-release ./helm/sample-api \
+            --namespace default \
+            --create-namespace \
+            --set image.tag=${{ env.IMAGE_TAG }} \
+            --set image.repository=${{ secrets.ACR_NAME }}.azurecr.io/sample-node-api \
+            --set postgresql.password=${{ secrets.DB_PASSWORD }} \
+            --set postgresql.host=postgresql-release-postgresql \
+            --wait # Optional: wait for resources to be ready
 #      # Placeholder for any post-deployment steps (e.g., smoke tests)
 #      # - name: Verify deployment
 #      #   run: |

--- a/readme
+++ b/readme
@@ -245,7 +245,8 @@ The GitHub Actions workflow defined in `.github/workflows/terraform-infra.yml` a
 
 CI/CD Pipeline Explanation
 
-The CI/CD pipelines are managed using GitHub Actions. The workflows are defined in the `.github/workflows/` directory.
+The CI/CD pipelines are managed using GitHub Actions. The primary workflows for infrastructure management (Terraform), application container building, and deployment to AKS have been configured for manual triggering. This provides direct control over when changes are provisioned or deployed to your Azure environment. You can trigger these workflows from the "Actions" tab of this repository.
+The workflows are defined in the `.github/workflows/` directory.
 
 1.  **Terraform Infrastructure Workflow (`terraform-infra.yml`)**
     *   **Purpose:** Automates the provisioning and management of the Azure infrastructure using Terraform.
@@ -275,16 +276,34 @@ To manually run this workflow:
 
 **Caution:** The `destroy` action will permanently delete your Azure infrastructure managed by this workflow. Use this option with extreme care and ensure you understand its consequences, especially in a production environment.
 
-2.  **Build and Push Docker Image (`build-and-push-docker.yml`) - Temporarily Disabled**
-    *   **Original Purpose:** Builds the Docker image for the sample Node.js API and pushes it to Azure Container Registry (ACR).
-    *   **Current Status:** This workflow is temporarily disabled by having its job steps commented out. The trigger is on pushes to `main` for changes in `app/**` or `app/Dockerfile`.
+2.  **Build and Push Docker Image (`Build App Container` workflow)**
+    *   **Purpose:** Builds the Docker image for the sample Node.js application (from `app/Dockerfile`) and pushes it to Azure Container Registry (ACR). The image will be tagged with the provided input tag and `latest`, and will be available at `${{ secrets.ACR_NAME }}.azurecr.io/hello-world`.
+    *   **Trigger:** Manually triggered via `workflow_dispatch` from the "Actions" tab of the GitHub repository.
+        *   Select the "**Build App Container**" workflow.
+        *   Provide the required `image_tag` input (e.g., `v1.0.0`, `my-feature-branch`, or `latest`).
+    *   **Status:** Active. This workflow will perform real build and push operations to your ACR.
+    *   **Required Secrets:**
+        *   `AZ_CRED`: Azure service principal credentials for logging into Azure.
+        *   `ACR_NAME`: The name of your Azure Container Registry.
 
-3.  **Deploy to AKS (`deploy-to-aks.yml`) - Temporarily Disabled**
-    *   **Original Purpose:** Deploys the sample Node.js API and PostgreSQL to the Azure Kubernetes Service (AKS) cluster using Helm charts.
-    *   **Current Status:** This workflow is temporarily disabled by having its job steps commented out. The trigger is on pushes to `main` for changes in `helm/**` or the workflow file itself.
+3.  **Deploy to AKS (`Deploy to AKS` workflow)**
+    *   **Purpose:** Deploys or upgrades the PostgreSQL Helm chart (release name: `postgresql-release`) and the sample Node.js API Helm chart (release name: `sample-api-release`) to the configured Azure Kubernetes Service (AKS) cluster.
+    *   **Trigger:** Manually triggered via `workflow_dispatch` from the "Actions" tab of the GitHub repository.
+        *   Select the "**Deploy to AKS**" workflow.
+        *   Provide the required `image_tag` input. This tag should correspond to an existing image tag in your ACR for the `sample-node-api` (e.g., `${{ secrets.ACR_NAME }}.azurecr.io/sample-node-api:<image_tag>`).
+    *   **Status:** Active. This workflow will perform real deployment operations to your AKS cluster.
+    *   **Helm Configuration Notes:**
+        *   PostgreSQL is deployed as `postgresql-release`. The sample API Helm chart expects the PostgreSQL service to be available at `postgresql-release-postgresql.default.svc.cluster.local`.
+        *   The sample API is deployed as `sample-api-release`.
+    *   **Required Secrets:**
+        *   `AZ_CRED`: Azure service principal credentials.
+        *   `AZ_RESOURCE_GROUP`: The name of the Azure resource group containing your AKS cluster.
+        *   `AZ_AKS_CLUSTER_NAME`: The name of your AKS cluster.
+        *   `DB_PASSWORD`: Password for the PostgreSQL database, used by both Helm charts.
+        *   `ACR_NAME`: The name of your Azure Container Registry, used to pull the `sample-node-api` image.
 
 **Note on Workflow Activation:**
-The application build and deployment workflows (`build-and-push-docker.yml` and `deploy-to-aks.yml`) can be re-enabled by uncommenting their job steps once the infrastructure is successfully provisioned and ACR/AKS details are available and configured (potentially as secrets or outputs from the Terraform workflow).
+The `terraform-infra.yml` workflow description above still reflects its original push trigger. It has also been updated to manual trigger as described in its dedicated "Manually Triggering the Terraform Workflow" section. The application build and deployment workflows (`Build App Container` and `Deploy to AKS`) are now active and manually triggered as described above.
 Deployment Process
 Build and Push Docker Image:
 


### PR DESCRIPTION
This commit updates the `build-and-push-docker.yml` and `deploy-to-aks.yml` GitHub Actions workflows to be manually triggerable. It also uncomments their
job steps, making them fully operational.

Modifications:

1.  **`build-and-push-docker.yml`:**
    *   Changed trigger to be manual.
    *   Added `image_tag` input (default: `latest`).
    *   Uncommented and updated steps to build the Docker image from
        `./app` and push it to ACR using `secrets.ACR_NAME` with the
        provided `image_tag` and `latest`.

2.  **`deploy-to-aks.yml`:**
    *   Changed trigger to be manual.
    *   Added `image_tag` input (default: `latest`) for the API.
    *   Uncommented all steps to:
        *   Set up Azure login, kubectl, and Helm.
        *   Deploy/upgrade PostgreSQL Helm chart (release: `postgresql-release`).
        *   Deploy/upgrade sample API Helm chart (release: `sample-api-release`)
            using the specified `image_tag` from `secrets.ACR_NAME`.
    *   References necessary secrets (`AZ_CRED`, `AZ_RESOURCE_GROUP`,
        `AZ_AKS_CLUSTER_NAME`, `DB_PASSWORD`, `ACR_NAME`).

3.  **`readme`:**
    *   Updated documentation for both workflows to reflect manual
        triggering, input parameters, and required secrets.
    *   Clarified that these workflows are now active.